### PR TITLE
[codex] Fix macOS localization detection

### DIFF
--- a/macosx/Info.plist.in
+++ b/macosx/Info.plist.in
@@ -4,6 +4,45 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>ar</string>
+		<string>ca</string>
+		<string>ca-ES-valencia</string>
+		<string>cs</string>
+		<string>da</string>
+		<string>de</string>
+		<string>el</string>
+		<string>en</string>
+		<string>en-GB</string>
+		<string>eo</string>
+		<string>es</string>
+		<string>et</string>
+		<string>eu</string>
+		<string>fi</string>
+		<string>fr</string>
+		<string>gl</string>
+		<string>is</string>
+		<string>it</string>
+		<string>ka</string>
+		<string>ko</string>
+		<string>nl</string>
+		<string>nn</string>
+		<string>pl</string>
+		<string>pt</string>
+		<string>pt-BR</string>
+		<string>ru</string>
+		<string>sl</string>
+		<string>sr</string>
+		<string>sr-Latn</string>
+		<string>sv</string>
+		<string>tr</string>
+		<string>uk</string>
+		<string>zh-Hans</string>
+		<string>zh-Hant</string>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>${MACOSX_BUNDLE_BUNDLE_EXECUTABLE}</string>
 	<key>CFBundleGetInfoString</key>

--- a/src/core/utils/loadtranslation.cpp
+++ b/src/core/utils/loadtranslation.cpp
@@ -66,6 +66,14 @@ void Utils::loadTranslation(const QString& lang)
   // "sr-latin". Both "sr@ijekavian" and "sr@ijekavianlatin" give "sr-ijekavia",
   // so this case cannot be fixed.
   for (auto it = languages.begin(); it != languages.end(); ++it) {
+    if (it->startsWith(QLatin1String("zh-Hans"))) {
+      *it = QLatin1String("zh_CN");
+      continue;
+    }
+    if (it->startsWith(QLatin1String("zh-Hant"))) {
+      *it = QLatin1String("zh_TW");
+      continue;
+    }
     const int len = it->length();
     if (const int dashPos = it->lastIndexOf(QLatin1Char('-'));
         dashPos > 0 && dashPos < len -1) {


### PR DESCRIPTION
## Summary

This fixes macOS localization startup for the Qt app bundle so bundled `.qm`
translations can be selected correctly on first launch.

## Root cause

The macOS app bundle ships translation files, but its `Info.plist` does not
declare the localizations supported by the bundle. In addition, language
identifiers such as `zh-Hans` and `zh-Hant`, which are common on macOS, pass
through Kid3's current normalization as `zh@Hans`/`zh@Hant` instead of matching
the existing `zh_CN`/`zh_TW` translation files.

## Changes

- Declare the app bundle localizations in `macosx/Info.plist.in` and allow mixed localizations.
- Normalize `zh-Hans*` to `zh_CN` and `zh-Hant*` to `zh_TW` before the generic dash-to-underscore/@ conversion.

## Validation

- `plutil -lint macosx/Info.plist.in`
- `git diff --check`

Full build not run in this environment.
